### PR TITLE
Introduce caching to the database and improve table population

### DIFF
--- a/bot/core/timer.py
+++ b/bot/core/timer.py
@@ -76,7 +76,7 @@ class Timer:
         """Cancel all currently delayed tasks in this timer."""
         logger.debug(f"Aborting all delayed tasks from {self.id}")
 
-        for task in self.delayed_tasks.copy():
+        for task in self.delayed_tasks.values():
             task.cancel()
 
     async def _postpone(self, task_name: t.Hashable, coro: t.Coroutine, delay: t.Union[int, float]) -> None:

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -157,7 +157,7 @@ class DBTable(metaclass=Singleton):
             db_entry = {}
             for col_name, record in zip(columns, entry):
                 # Convert to specified type
-                with suppress(IndexError):
+                with suppress(IndexError, TypeError):
                     _type = self.cache_columns[col_name]
                     record = _type(record)
                 db_entry[col_name] = record

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -155,7 +155,7 @@ class DBTable(metaclass=Singleton):
             for col_name, record in zip(columns, entry):
                 # Convert to specified type
                 with suppress(IndexError):
-                    _type = self.col_types[col_name]
+                    _type = self.columns[col_name]
                     record = _type(record)
                 db_entry[col_name] = record
             # Store the cache model into the cache

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -166,17 +166,17 @@ class DBTable(metaclass=Singleton):
             cache_entry = self._cache_model(**db_entry)
             self.cache[key] = cache_entry
 
-    def update_cache(self, primary_value: str, update_key: str, update_value: t.Any) -> None:
+    def cache_update(self, key: str, column: str, value: t.Any) -> None:
         """
         Update the stored cache value for `update_key` on `primary_value` to given `update_value`.
         """
-        setattr(self.cache[primary_value], update_key, update_value)
+        setattr(self.cache[key], column, value)
 
-    def cache_get(self, primary_value: str, attribute: str) -> t.Any:
+    def cache_get(self, key: str, column: str) -> t.Any:
         """
         Obtain the value of `attribute` stored in cache for `primary_value`
         """
-        return getattr(self.cache[primary_value], attribute)
+        return getattr(self.cache[key], column)
 
     @classmethod
     def reference(cls) -> "DBTable":

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -1,6 +1,8 @@
 import typing as t
 from abc import abstractmethod
+from collections import defaultdict
 from contextlib import suppress
+from dataclasses import field, make_dataclass
 from importlib import import_module
 
 import asyncpg
@@ -34,12 +36,30 @@ class DBTable(metaclass=Singleton):
     """
     This is a basic database table structure model.
 
-    It isn't supposed to be used on it's own but rather
-    as a parent class for all database table classes.
+    This class automatically creates the initial database
+    tables accordingly to `columns` dict which is a mandantory
+    class parameter defined in the top-level class, it should
+    look like this:
+    columns = {
+        "column_name": "SQL creation syntax",
+        "example": "NUMERIC(40) UNIQUE NOT NULL"
+        ...
+    }
 
-    This class stores multiple methods to make executing SQL
-    queries easier together with the `_populate` method
-    which is here to initiate the database and create tables.
+    After the table is populated, caching will be automatically
+    set up based on the `caching` dict which is an optional class
+    parameter defined in the top-level class, if this parameter isn't
+    defined, caching will be skipped. Example for caching:
+    caching = {
+        "key": "table_name",  # This will be the key for the stored `cache` dict
+
+        # These will be the entries for the cache
+        "column_name": (python datatype, default_value),
+        "column_name2": python datatype  # default_value is optional
+    }
+
+    There are also multiple methods which serves as an abstraction
+    layer for for executing raw SQL code.
 
     There is also a special `reference` classmethod which will
     return the running instance (from the singleton model).
@@ -49,6 +69,7 @@ class DBTable(metaclass=Singleton):
         self.table = table_name
         self.pool = self.database.pool
         self.timeout = self.database.timeout
+        self.cache = {}
 
     @abstractmethod
     async def __async_init__(self) -> None:
@@ -62,15 +83,22 @@ class DBTable(metaclass=Singleton):
 
     async def _init(self) -> None:
         """
-        This method calls `__async_init__` method from top-level
-        table class and calles `_populate` which crates the
-        initial table structure accordingly to the top-level defined
-        `populate_command` sql query.
+        This method calls `_populate` and `_make_cache`
+        to make all the db tables and create the table cache.
+        After that, `__async_init__` method is called which
+        refers to top-level async initialization, if this
+        method isn't defined, nothing will happen.
+
+        This also makes sure that `columns` dictionary is
+        defined properly in the top-level class..
         """
-        with suppress(NotImplementedError):
-            await self.__async_init__()
+        if not hasattr(self, "columns") or not isinstance(self.columns, dict):
+            raise RuntimeError(f"Table {self.__class__} doesn't have a `columns` dict defined properly.")
 
         await self._populate()
+        await self._make_cache()
+        with suppress(NotImplementedError):
+            await self.__async_init__()
 
     async def _populate(self) -> None:
         """
@@ -80,13 +108,60 @@ class DBTable(metaclass=Singleton):
         This method also calls `__async_init__` method on top level table
         (if there is one).
         """
-        if not hasattr(self, "populate_command"):
-            logger.warning(f"Table {self.__class__} doesn't have a `populate_command` attribute set, skipping populating.")
-            return
+        table_structure = ",\n".join(f"{column} {sql_details}" for column, sql_details in self.columns.items())
+        populate_command = f"CREATE TABLE IF NOT EXISTS {self.table} (\n{table_structure}\n)"
 
         logger.trace(f"Populating {self.__class__}")
         async with self.pool.acquire(timeout=self.timeout) as db:
-            await db.execute(self.populate_command)
+            await db.execute(populate_command)
+
+    async def _make_cache(self) -> None:
+        """
+        Crate and populate basic caching model from top-level `self.caching`.
+        """
+        if not hasattr(self, "caching") or not isinstance(self.caching, dict):
+            logger.trace(f"Skipping defining cache for {self.__class__}, `caching` dict wasn't specified")
+            return
+
+        self.columns = {}
+        cache_key_type, self._cache_key = self.caching.pop("key")
+        self.columns[self._cache_key] = cache_key_type
+
+        # Create cache model
+        field_list = []
+        for column, specification in self.caching.items():
+            if isinstance(specification, tuple):
+                val = (column, specification[0], field(default=specification[1]))
+                _type = specification[0]
+            elif specification is None:
+                val = column
+                _type = None
+            else:
+                val = (column, specification)
+                _type = specification
+
+            field_list.append(val)
+            self.columns[column] = _type
+
+        self._cache_model = make_dataclass("Entry", field_list)
+
+        # Create and populate the cache
+        self.cache = defaultdict(self._cache_model)
+        columns = list(self.columns.keys())
+
+        entries = await self.db_get(columns)  # Get db entries to store
+        for entry in entries:
+            db_entry = {}
+            for col_name, record in zip(columns, entry):
+                # Convert to specified type
+                with suppress(IndexError):
+                    _type = self.col_types[col_name]
+                    record = _type(record)
+                db_entry[col_name] = record
+            # Store the cache model into the cache
+            key = db_entry.pop(self._cache_key)
+            cache_entry = self._cache_model(**db_entry)
+            self.cache[key] = cache_entry
 
     @classmethod
     def reference(cls) -> "DBTable":

--- a/bot/database/log_channels.py
+++ b/bot/database/log_channels.py
@@ -1,0 +1,110 @@
+import typing as t
+from dataclasses import dataclass
+
+from discord import Guild, TextChannel
+from loguru import logger
+
+from bot.core.bot import Bot
+from bot.database import DBTable, Database
+
+
+@dataclass
+class Entry:
+    """Class for storing the database rows of log_channels table."""
+    server: int = 0
+    mod: int = 0
+    message: int = 0
+    member: int = 0
+    join: int = 0
+
+
+class LogChannels(DBTable):
+    """
+    This table stores all guild-specific roles:
+    * `server` log channel
+    * `mod` log channel
+    * `message` log channel
+    * `member` log channel
+    * `join` log channel
+    Under the single `serverid` column
+    """
+
+    columns = {
+        "serverid": "NUMERIC(40) UNIQUE NOT NULL",
+        "server": "NUMERIC(40) DEFAULT 0",
+        "mod": "NUMERIC(40) DEFAULT 0",
+        "message": "NUMERIC(40) DEFAULT 0",
+        "member": "NUMERIC(40) DEFAULT 0",
+        "join": "NUMERIC(40) DEFAULT 0"
+    }
+
+    caching = {
+        "key": (int, "serverid"),
+
+        "server": (int, 0),
+        "mod": (int, 0),
+        "message": (int, 0),
+        "member": (int, 0),
+        "join": (int, 0)
+    }
+
+    def __init__(self, bot: Bot, database: Database):
+        super().__init__(database, "log_channels")
+        self.bot = bot
+        self.database = database
+        self.cache: t.Dict[int, Entry] = {}
+
+    async def _set_channel(self, channel_name: str, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        """Set a `channel_name` column to store `channel.id` for the specific `guild.id`."""
+        if isinstance(channel, TextChannel):
+            channel = channel.id
+        if isinstance(guild, Guild):
+            guild = guild.id
+
+        logger.debug(f"Setting {channel_name}-log channel on {guild} to <#{channel}>")
+        await self.db_upsert(
+            columns=["serverid", channel_name],
+            values=[guild, channel],
+            conflict_column="serverid"
+        )
+        self.update_cache(guild, channel_name, channel)
+
+    def _get_channel(self, channel_name: str, guild: t.Union[Guild, int]) -> int:
+        """Get a `role_name` column for specific `guild` from cache."""
+        if isinstance(guild, Guild):
+            guild = guild.id
+        return self.cache_get(guild, channel_name)
+
+    async def set_server_log(self, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        await self._set_channel("server", guild, channel)
+
+    async def set_mod_log(self, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        await self._set_channel("mod", guild, channel)
+
+    async def set_message_log(self, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        await self._set_channel("message", guild, channel)
+
+    async def set_member_log(self, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        await self._set_channel("member", guild, channel)
+
+    async def set_join_log(self, guild: t.Union[Guild, int], channel: t.Union[TextChannel, int]) -> None:
+        await self._set_channel("join", guild, channel)
+
+    def get_server_log(self, guild: t.Union[Guild, int]) -> int:
+        return self._get_channel("server", guild)
+
+    def get_mod_log(self, guild: t.Union[Guild, int]) -> int:
+        return self._get_channel("mod", guild)
+
+    def get_message_log(self, guild: t.Union[Guild, int]) -> int:
+        return self._get_channel("message", guild)
+
+    def get_member_log(self, guild: t.Union[Guild, int]) -> int:
+        return self._get_channel("member", guild)
+
+    def get_join_log(self, guild: t.Union[Guild, int]) -> int:
+        return self._get_channel("join", guild)
+
+
+async def load(bot: Bot, database: Database) -> None:
+    await database.add_table(LogChannels(bot, database))

--- a/bot/database/roles.py
+++ b/bot/database/roles.py
@@ -1,6 +1,5 @@
 import typing as t
 from dataclasses import dataclass
-from textwrap import dedent
 
 from discord import Guild, Role
 from loguru import logger
@@ -25,40 +24,28 @@ class Roles(DBTable):
     * `staff` role
     Under the single `serverid` column
     """
-    populate_command = dedent("""
-        CREATE TABLE IF NOT EXISTS roles (
-            serverid NUMERIC(40) UNIQUE NOT NULL,
-            _default NUMERIC(40) DEFAULT 0,
-            muted NUMERIC(40) DEFAULT 0,
-            staff NUMERIC(40) DEFAULT 0
-        )
-    """)
+    columns = {
+        "serverid": "NUMERIC(40) UNIQUE NOT NULL",
+        "_default": "NUMERIC(40) DEFAULT 0",
+        "muted": "NUMERIC(40) DEFAULT 0",
+        "staff": "NUMERIC(40) DEFAULT 0",
+    }
+    caching = {
+        "key": (int, "serverid"),
+
+        "_default": (int, 0),
+        "muted": (int, 0),
+        "staff": (int, 0)
+    }
 
     def __init__(self, bot: Bot, database: Database):
         super().__init__(database, "roles")
         self.bot = bot
         self.database = database
-        self.cache: t.Dict[int, Entry] = {}
-
-    async def __async_init__(self):
-        """
-        Obtain all database rows and populate the cache
-        with them.
-        """
-        entries = await self.db_get(columns=["serverid", "_default", "muted", "staff"])
-
-        for entry in entries:
-            lst_entry = list(entry)
-            self.cache[lst_entry[0]] = Entry(*lst_entry[1:])
 
     def update_cache(self, server_id: int, role: str, value: int) -> None:
         """Update or add roles in stored cache."""
-        if server_id in self.cache:
-            setattr(self.cache[server_id], role, value)
-        else:
-            roles = {"_default": 0, "muted": 0, "staff": 0}
-            roles.update({role: value})
-            self.cache[server_id] = self.Entry(**roles)
+        setattr(self.cache[server_id], role, value)
 
     async def _set_role(self, role_name: str, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> None:
         """Set a `role_name` column to store `role` for the specific `guild`."""

--- a/bot/database/roles.py
+++ b/bot/database/roles.py
@@ -43,10 +43,6 @@ class Roles(DBTable):
         self.bot = bot
         self.database = database
 
-    def update_cache(self, server_id: int, role: str, value: int) -> None:
-        """Update or add roles in stored cache."""
-        setattr(self.cache[server_id], role, value)
-
     async def _set_role(self, role_name: str, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> None:
         """Set a `role_name` column to store `role` for the specific `guild`."""
         if isinstance(guild, Guild):
@@ -66,7 +62,7 @@ class Roles(DBTable):
         """Get a `role_name` column for specific `guild` from cache."""
         if isinstance(guild, Guild):
             guild = guild.id
-        return getattr(self.cache[guild], role_name)
+        return self.cache_get(guild, role_name)
 
     async def set_default_role(self, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> None:
         await self._set_role("_default", guild, role)
@@ -80,7 +76,7 @@ class Roles(DBTable):
     def get_default_role(self, guild: t.Union[Guild, int]) -> int:
         role = self._get_role("_default", guild)
         if role == 0:
-            role = guild.default_role
+            role = guild.default_role.id
 
         return role
 


### PR DESCRIPTION
## Abstract

While there's nothing wrong with the main functionality of our current database system there are 2 things which I think still needs improving, those are: 

### Caching system

If we want to implement caching into any of the tables, the way our current database model is set up doesn't help us at all. We need to define everything in the top-level `DBTable` class.
This isn't a problem if only a few tables were being cached but that's not the case, we'll need to cache most of the tables and since the caching implementation is very repetitive in nature, I find it worth to implement a better system which does this automatically without too much repetition in the top-level classes.

### Populate command

For example using a `populate_command` class parameter requires extended use of fairly similar SQL syntax. This syntax will always just say something along these lines:
```sql
CREATE TABLE IF NOT EXISTS [table_name] (
    [column1] [sqlargs],
    [column2] [sqlargs],
   ...
)
```
where values in `[]` represent the variable parameters while the rest of the syntax stays the same

## Proposed solutions

### Caching System

In order to avoid the cache repetition described in the Abstract, I've decided to implement it on the lower-level class of `DBTable` directly. In order to keep things consistent, I've decided to use another class parameter which will be simply called `caching`.
Using this parameter will be optional and when it won't be defined, caching will be skipped.

Example formatting of the new `caching` class parameter:
```py
class FooTable(DBTable):
    caching = {
        "key": (int, "serverid"),

        "_default": int,
        "muted": (int, 0),
        "staff": None
    }
   ...
```

The `"key"` is used to hold the column which will be used as a unique identifier, under which the other column values will be stored, you can think of it as the primary key for caching. This is the key you'll use to access the cache itself (`self.cache[some_serverid]`).

The rest of the values follow simple syntax guidelines: the key represents the name of that column, and the value can be one of the 3 examples shown above:

1. **`int`**: This value definition only provides the datatype which this column should be using. This is the type that will be used to convert the `asyncpg.Record`. in this case, the following would be stored to cache `int(specific_record)`
2. **`(int, 0)`**: This acts similarly to the above except it also provides a default value of `0`.
3. **`None`**: This syntax will assume the same as the one with the pure data type, but the data type will be set to `t.Any` rather than something specific. If this type is used, you'll be storing the `asyncpg.Record` instances rather than any specified data type.

Using this cache in the top-level classes will be very easy due to the lower-level setter and getter functions.
These functions are: `DBTable.cache_get(key, column)` and `DBTable.cache_update(key, column, value)`. 
Here is a simple example usage of them:
```py
    async def _set_role(self, role_name: str, guild_id: int, role_id: int) -> None:
        """Set a `role_name` column to store `role_id` for the specific `guild_id`."""
        await self.db_upsert(
            columns=["serverid", role_name],
            values=[guild_id, role_id],
            conflict_column="serverid"
        )
        self.cache_update(guild.id, role_name, role.id)  # Cache setter function

    def _get_role(self, role_name: str, guild_id: int) -> int:
        """Get a `role_name` column for specific `guild_id` from cache."""
        return self.cache_get(guild_id, role_name)  # Cache getter function
```

## Populate command

This is a relatively straightforward fix, rather than defining the whole populate command which introduces a lot of repetition, defining a dictionary with columns as keys and SQL args for each table as the values we can avoid that repetition of the `populate_command` syntax and let the lower-layer `DBTable` fill in the rest of the SQL syntax automatically.

An example of this new syntax would be this:

```py
class FooTable(DBTable):
    columns = {
        "serverid": "NUMERIC(40) UNIQUE NOT NULL",
        "_default": "NUMERIC(40) DEFAULT 0",
        "muted": "NUMERIC(40) DEFAULT 0",
        "staff": "NUMERIC(40) DEFAULT 0",
    }
   ...
```

From there the way this works should be quite intuitive and a lot easier to understand.

## Working example

Making a new table using this improved populate structure which also includes caching is now very easy, as can be seen in this simple example:

```py
class FooTable(DBTable):
    columns = {
        "serverid": "NUMERIC(40) UNIQUE NOT NULL",
        "_default": "NUMERIC(40) DEFAULT 0",
        "muted": "NUMERIC(40) DEFAULT 0",
        "staff": "NUMERIC(40) DEFAULT 0",
    }
    caching = {
        "key": (int, "serverid"),

        "_default": int,
        "muted": (int, 0),
        "staff": None
    }

    def __init__(self, bot: Bot, database: Database):
        super().__init__(database, "roles")
        self.bot = bot
        self.database = database

    async def _set_role(self, role_name: str, guild_id: int, role_id: int) -> None:
        """Set a `role_name` column to store `role_id` for the specific `guild_id`."""
        await self.db_upsert(
            columns=["serverid", role_name],
            values=[guild_id, role_id],
            conflict_column="serverid"
        )
        self.cache_update(guild.id, role_name, role.id)  # Cache setter function

    def _get_role(self, role_name: str, guild_id: int) -> int:
        """Get a `role_name` column for specific `guild_id` from cache."""
        return self.cache_get(guild_id, role_name)  # Cache getter function
```