### PR TITLE
Add setup commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ class Roles(DBTable):
         await self.db_upsert(
             columns=["serverid", "staff_role"],
             values=[server_id, role_id],
-            conflict_column="serverid"
+            conflict_columns=["serverid"]
         )
 
     async def get_staff_role(self, server_id: int) -> asyncpg.Record:
@@ -238,7 +238,7 @@ class FooTable(DBTable):
         await self.db_upsert(
             columns=["serverid", role_name],
             values=[guild_id, role_id],
-            conflict_column="serverid"
+            conflict_columns=["serverid"]
         )
         self.cache_update(guild.id, role_name, role.id)  # Cache setter function
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,11 +184,11 @@ The table will be loaded with the bots initiation automatically.
 
 ### Using caching
 
-The database system also introduces a built-in way to easily use caching for your database. This means you can use synchronous functions to read your database from cache rather than making asynchronous calls to the database itself and reading it from there. Not only does that means you don't have to use asnyc fucntions, it also makes accessing the database data faster.
+The database system also introduces a built-in way to easily use caching for your database. This means you can use synchronous functions to read your database from cache rather than making asynchronous calls to the database itself and reading it from there. Not only does that means you don't have to use async functions, it also makes accessing the database data faster.
 
 Even through it's advantages, there are cases where caching isn't wanted in order to prevent using up too much memory. If this is your case, you don't have to do absolutely anything, just make the database as described in the section above, but if you do want caching, just read along.
 
-In order to use caching, all you need to do is specify the `caching` class parameter, similarely to the `columns` parameter, except this one is optional. By including it the lower-level methods will automatically populate a `self.cache` dictionary for you based on your caching structure in this dictionary. This class variable looks like this:
+In order to use caching, all you need to do is specify the `caching` class parameter, similarly to the `columns` parameter, except this one is optional. By including it the lower-level methods will automatically populate a `self.cache` dictionary for you based on your caching structure in this dictionary. This class variable looks like this:
 
 ```py
 class FooTable(DBTable):

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -11,10 +11,12 @@ PREFIX = config.COMMAND_PREFIX
 extensions = [
     "bot.cogs.moderation.lock",
     "bot.cogs.setup.roles",
+    "bot.cogs.setup.permissions",
     "bot.cogs.sudo",
 ]
 db_tables = [
-    "bot.database.roles"
+    "bot.database.roles",
+    "bot.database.permissions",
 ]
 
 bot = Bot(

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -10,6 +10,7 @@ PREFIX = config.COMMAND_PREFIX
 
 extensions = [
     "bot.cogs.moderation.lock",
+    "bot.cogs.setup.roles",
     "bot.cogs.sudo",
 ]
 db_tables = [

--- a/bot/cogs/moderation/lock.py
+++ b/bot/cogs/moderation/lock.py
@@ -66,11 +66,14 @@ class Lock(Cog):
         Disallow everyones permission to talk in this channel
         for given `duration` or indefinitely.
         """
+        if duration == float("inf"):
+            duration = None
+
         max_duration = await self.permissions_db.get_locktime(ctx.guild, ctx.author)
 
         if any([
-            not duration and max_duration is not None,
-            duration and max_duration is not None and duration > max_duration
+            not duration and max_duration != -1,
+            duration and max_duration != -1 and duration > max_duration
         ]):
             raise MissingPermissions(["sufficient_locktime"])
 

--- a/bot/cogs/setup/permissions.py
+++ b/bot/cogs/setup/permissions.py
@@ -1,0 +1,77 @@
+import textwrap
+
+from discord import Embed
+from discord.ext.commands import Cog, Context, RoleConverter, command
+
+from bot.core.bot import Bot
+from bot.core.converters import Duration
+from bot.database.permissions import Permissions
+from bot.utils.time import stringify_duration
+
+
+class PermissionsSetup(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.permissions_db: Permissions = Permissions.reference()
+
+    @command(aliases=["bantime"])
+    async def ban_time(self, ctx: Context, role: RoleConverter, duration: Duration) -> None:
+        """
+        Set maximum time users with specified role can ban users for.
+
+        If user have multiple roles with different ban times,
+        the ban time for role higher in the hierarchy will be preferred.
+        """
+        await self.permissions_db.set_bantime(ctx.guild, role, duration)
+
+    @command(aliases=["mutetime"])
+    async def mute_time(self, ctx: Context, role: RoleConverter, duration: Duration) -> None:
+        """
+        Set maximum time users with specified role can mute users for.
+
+        If user have multiple roles with different mute times,
+        the mute time for role higher in the hierarchy will be preferred.
+        """
+        await self.permissions_db.set_mutetime(ctx.guild, role, duration)
+
+    @command(aliases=["locktime"])
+    async def lock_time(self, ctx: Context, role: RoleConverter, duration: Duration) -> None:
+        """
+        Set maximum time users with specified role can lock channels for.
+
+        If user have multiple roles with different lock times,
+        the lock time for role higher in the hierarchy will be preferred.
+        """
+        await self.permissions_db.set_locktime(ctx.guild, role, duration)
+
+    @command(aliases=["showpermissions"])
+    async def show_permissions(self, ctx: Context, role: RoleConverter) -> None:
+        """Show configured role permissions for the given `role`"""
+        ban_time = await self.permissions_db.get_bantime(ctx.guild, role)
+        mute_time = await self.permissions_db.get_mutetime(ctx.guild, role)
+        lock_time = await self.permissions_db.get_locktime(ctx.guild, role)
+
+        if ban_time:
+            ban_time = stringify_duration(ban_time)
+        if mute_time:
+            mute_time = stringify_duration(mute_time)
+        if lock_time:
+            lock_time = stringify_duration(lock_time)
+
+        embed = Embed(
+            description=textwrap.dedent(
+                f"""
+                **Permissions for {role.mention} role**
+
+                Maximum ban time: `{ban_time}`
+                Maximum mute time: `{mute_time}`
+                Maximum Lock time: `{lock_time}`
+                """
+            )
+        )
+
+        await ctx.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(PermissionsSetup(bot))

--- a/bot/cogs/setup/permissions.py
+++ b/bot/cogs/setup/permissions.py
@@ -23,6 +23,7 @@ class PermissionsSetup(Cog):
         the ban time for role higher in the hierarchy will be preferred.
         """
         await self.permissions_db.set_bantime(ctx.guild, role, duration)
+        await ctx.send(":white_check_mark: Permissions updated.")
 
     @command(aliases=["mutetime"])
     async def mute_time(self, ctx: Context, role: RoleConverter, duration: Duration) -> None:
@@ -33,6 +34,7 @@ class PermissionsSetup(Cog):
         the mute time for role higher in the hierarchy will be preferred.
         """
         await self.permissions_db.set_mutetime(ctx.guild, role, duration)
+        await ctx.send(":white_check_mark: Permissions updated.")
 
     @command(aliases=["locktime"])
     async def lock_time(self, ctx: Context, role: RoleConverter, duration: Duration) -> None:
@@ -43,6 +45,7 @@ class PermissionsSetup(Cog):
         the lock time for role higher in the hierarchy will be preferred.
         """
         await self.permissions_db.set_locktime(ctx.guild, role, duration)
+        await ctx.send(":white_check_mark: Permissions updated.")
 
     @command(aliases=["showpermissions"])
     async def show_permissions(self, ctx: Context, role: RoleConverter) -> None:

--- a/bot/cogs/setup/roles.py
+++ b/bot/cogs/setup/roles.py
@@ -1,0 +1,29 @@
+from discord.ext.commands import Cog, Context, RoleConverter, command
+
+from bot.core.bot import Bot
+from bot.database.roles import Roles
+
+
+class RolesSetup(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.roles_db: Roles = Roles.reference()
+
+    @command(aliases=["defaultrole"])
+    async def default_role(self, ctx: Context, role: RoleConverter) -> None:
+        """Setup default role."""
+        await self.roles_db.set_default_role(ctx.guild, role)
+
+    @command(aliases=["staffrole"])
+    async def staff_role(self, ctx: Context, role: RoleConverter) -> None:
+        """Handle the server setup."""
+        await self.roles_db.set_staff_role(ctx.guild, role)
+
+    @command(aliases=["mutedrole"])
+    async def muted_role(self, ctx: Context, role: RoleConverter) -> None:
+        """Handle the server setup."""
+        await self.roles_db.set_muted_role(ctx.guild, role)
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(RolesSetup(bot))

--- a/bot/cogs/setup/roles.py
+++ b/bot/cogs/setup/roles.py
@@ -1,3 +1,6 @@
+import textwrap
+
+from discord import Embed, Role
 from discord.ext.commands import Cog, Context, RoleConverter, command
 
 from bot.core.bot import Bot
@@ -23,6 +26,33 @@ class RolesSetup(Cog):
     async def muted_role(self, ctx: Context, role: RoleConverter) -> None:
         """Handle the server setup."""
         await self.roles_db.set_muted_role(ctx.guild, role)
+
+    @command(aliases=["showroles"])
+    async def show_roles(self, ctx: Context) -> None:
+        """Show saved roles for this server."""
+        default = ctx.guild.get_role(self.roles_db.get_default_role(ctx.guild))
+        staff = ctx.guild.get_role(self.roles_db.get_staff_role(ctx.guild))
+        muted = ctx.guild.get_role(self.roles_db.get_muted_role(ctx.guild))
+
+        if isinstance(default, Role):
+            default = default.mention
+        if isinstance(staff, Role):
+            staff = staff.mention
+        if isinstance(muted, Role):
+            muted = muted.mention
+
+        embed = Embed(
+            title="Configured role settings",
+            description=textwrap.dedent(
+                f"""
+                Default role: {default}
+                Staff role: {staff}
+                Muted role: {muted}
+                """
+            )
+        )
+
+        await ctx.send(embed=embed)
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/setup/roles.py
+++ b/bot/cogs/setup/roles.py
@@ -20,19 +20,19 @@ class RolesSetup(Cog):
 
     @command(aliases=["staffrole"])
     async def staff_role(self, ctx: Context, role: RoleConverter) -> None:
-        """Handle the server setup."""
+        """Setup the staff role."""
         await self.roles_db.set_staff_role(ctx.guild, role)
         await ctx.send(":white_check_mark: Role updated.")
 
     @command(aliases=["mutedrole"])
     async def muted_role(self, ctx: Context, role: RoleConverter) -> None:
-        """Handle the server setup."""
+        """Setup the muted role."""
         await self.roles_db.set_muted_role(ctx.guild, role)
         await ctx.send(":white_check_mark: Role updated.")
 
     @command(aliases=["showroles"])
     async def show_roles(self, ctx: Context) -> None:
-        """Show saved roles for this server."""
+        """Show configured roles in the server."""
         default = ctx.guild.get_role(self.roles_db.get_default_role(ctx.guild))
         staff = ctx.guild.get_role(self.roles_db.get_staff_role(ctx.guild))
         muted = ctx.guild.get_role(self.roles_db.get_muted_role(ctx.guild))

--- a/bot/cogs/setup/roles.py
+++ b/bot/cogs/setup/roles.py
@@ -16,16 +16,19 @@ class RolesSetup(Cog):
     async def default_role(self, ctx: Context, role: RoleConverter) -> None:
         """Setup default role."""
         await self.roles_db.set_default_role(ctx.guild, role)
+        await ctx.send(":white_check_mark: Role updated.")
 
     @command(aliases=["staffrole"])
     async def staff_role(self, ctx: Context, role: RoleConverter) -> None:
         """Handle the server setup."""
         await self.roles_db.set_staff_role(ctx.guild, role)
+        await ctx.send(":white_check_mark: Role updated.")
 
     @command(aliases=["mutedrole"])
     async def muted_role(self, ctx: Context, role: RoleConverter) -> None:
         """Handle the server setup."""
         await self.roles_db.set_muted_role(ctx.guild, role)
+        await ctx.send(":white_check_mark: Role updated.")
 
     @command(aliases=["showroles"])
     async def show_roles(self, ctx: Context) -> None:

--- a/bot/core/converters.py
+++ b/bot/core/converters.py
@@ -133,6 +133,9 @@ class Duration(TimeDelta):
         super `TimeDelta` converter. After that, simply change
         the relative delta into the amount of seconds it represents.
         """
+        if duration in ["-1", "inf", "infinite", "infinity"]:
+            return float("inf")
+
         delta = await super().convert(ctx, duration)
 
         now = datetime.utcnow()

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -268,7 +268,7 @@ class DBTable(metaclass=Singleton):
 
         await self.db_execute(sql, values)
 
-    async def db_upsert(self, columns: t.List[str], values: t.List[str], conflict_column: str) -> None:
+    async def db_upsert(self, columns: t.List[str], values: t.List[str], conflict_columns: t.List[str]) -> None:
         """
         This method serves as an abstraction layer
         from using SQL syntax in the top-level database
@@ -277,15 +277,17 @@ class DBTable(metaclass=Singleton):
         """
         sql_columns = ", ".join(columns)
         sql_values = ", ".join(f"${n + 1}" for n in range(len(values)))
+        sql_conflict_columns = ", ".join(conflict_columns)
+
         sql_update = ""
         for index, column in enumerate(columns):
-            if column != conflict_column:
+            if column not in conflict_columns:
                 sql_update += f"{column}=${index + 1}"
 
         sql = f"""
         INSERT INTO {self.table} ({sql_columns})
         VALUES ({sql_values})
-        ON CONFLICT ({conflict_column}) DO
+        ON CONFLICT ({sql_conflict_columns}) DO
         UPDATE SET {sql_update}
         """
 

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -155,7 +155,7 @@ class DBTable(metaclass=Singleton):
         entries = await self.db_get(columns)  # Get db entries to store
         for entry in entries:
             db_entry = {}
-            for col_name, record in zip(columns, entry):
+            for col_name, record in zip(columns, *iter(entry)):
                 # Convert to specified type
                 with suppress(IndexError, TypeError):
                     _type = self.cache_columns[col_name]
@@ -243,9 +243,9 @@ class DBTable(metaclass=Singleton):
         table class, it runs the basic selection (get)
         query without needing to use SQL syntax at all.
         """
-        sql = f"SELECT {' ,'.join(columns)} FROM {self.table}"
+        sql = f"SELECT ({', '.join(columns)}) FROM {self.table}"
         if specification:
-            sql += f" WHERE {specification}"
+            sql += f" WHERE ({specification})"
 
         if len(columns) == 1:
             return await self.db_fetchone(sql, sql_args)

--- a/bot/database/log_channels.py
+++ b/bot/database/log_channels.py
@@ -67,7 +67,7 @@ class LogChannels(DBTable):
             values=[guild, channel],
             conflict_columns=["serverid"]
         )
-        self.update_cache(guild, channel_name, channel)
+        self.cache_update(guild, channel_name, channel)
 
     def _get_channel(self, channel_name: str, guild: t.Union[Guild, int]) -> int:
         """Get a `role_name` column for specific `guild` from cache."""

--- a/bot/database/log_channels.py
+++ b/bot/database/log_channels.py
@@ -65,7 +65,7 @@ class LogChannels(DBTable):
         await self.db_upsert(
             columns=["serverid", channel_name],
             values=[guild, channel],
-            conflict_column="serverid"
+            conflict_columns=["serverid"]
         )
         self.update_cache(guild, channel_name, channel)
 

--- a/bot/database/permissions.py
+++ b/bot/database/permissions.py
@@ -1,0 +1,90 @@
+import typing as t
+from dataclasses import dataclass
+
+from discord import Guild, Role
+from loguru import logger
+
+from bot.core.bot import Bot
+from bot.database import DBTable, Database
+
+
+@dataclass
+class Entry:
+    """Class for storing the database rows of roles table."""
+    _default: int
+    muted: int
+    staff: int
+
+
+class Permissions(DBTable):
+    """
+    This table stores these permissions:
+    * `bantime` maximum amount of time (in seconds) for temp-ban
+    * `mutetime` maximum amount of time (in seconds) for temp-mute
+    * `locktime` maximum amount of time (in seconds) for channel lock
+    For given `role` in given `serverid`
+    """
+    columns = {
+        "serverid": "NUMERIC(40) NOT NULL",
+        "role": "NUMERIC(40) DEFAULT 0",
+        "bantime": "INTEGER DEFAULT 0",
+        "mutetime": "INTEGER DEFAULT 0",
+        "locktime": "INTEGER DEFAULT 0",
+        "UNIQUE": "(serverid, role)"
+    }
+
+    def __init__(self, bot: Bot, database: Database):
+        super().__init__(database, "permissions")
+        self.bot = bot
+        self.database = database
+
+    async def _set_permission(self, permission_name: str, guild: t.Union[Guild, int], role: t.Union[Role, int], value: t.Any) -> None:
+        """Set a `role_name` column to store `role` for the specific `guild`."""
+        if isinstance(guild, Guild):
+            guild = guild.id
+        if isinstance(role, Role):
+            role = role.id
+
+        logger.debug(f"Setting {permission_name} on {guild} for <@&{role}> to {value}")
+        await self.db_upsert(
+            columns=["serverid", "role", permission_name],
+            values=[guild, role, value],
+            conflict_columns=["serverid", "role"]
+        )
+
+    async def _get_permission(self, permission_name: str, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> t.Any:
+        """Get a `role_name` column for specific `guild` from cache."""
+        if isinstance(guild, Guild):
+            guild = guild.id
+        if isinstance(role, Role):
+            role = role.id
+
+        record = await self.db_get(
+            columns=[permission_name],
+            specification="serverid=$1 AND role=$2",
+            sql_args=[guild, role]
+        )
+
+        return record[0]
+
+    async def set_bantime(self, guild: t.Union[Guild, int], role: t.Union[Role, int], value: int) -> None:
+        await self._set_permission("bantime", guild, role, value)
+
+    async def set_mutetime(self, guild: t.Union[Guild, int], role: t.Union[Role, int], value: int) -> None:
+        await self._set_permission("mutetime", guild, role, value)
+
+    async def set_locktime(self, guild: t.Union[Guild, int], role: t.Union[Role, int], value: int) -> None:
+        await self._set_permission("locktime", guild, role, value)
+
+    async def get_bantime(self, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> int:
+        return await self._get_permission("bantime", guild, role)
+
+    async def get_mutetime(self, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> int:
+        return await self._get_permission("mutetime", guild, role)
+
+    async def get_locktime(self, guild: t.Union[Guild, int], role: t.Union[Role, int]) -> int:
+        return await self._get_permission("locktime", guild, role)
+
+
+async def load(bot: Bot, database: Database) -> None:
+    await database.add_table(Permissions(bot, database))

--- a/bot/database/permissions.py
+++ b/bot/database/permissions.py
@@ -85,9 +85,8 @@ class Permissions(DBTable):
             identifier = guild.get_member(user.id)
 
         if isinstance(identifier, Member):
-            # TODO: Uncomment this (commented for testing)
-            # if identifier.guild_permissions().administrator:
-            #     return None
+            if identifier.guild_permissions().administrator:
+                return None
 
             # Follow role hierarchy from most important role to everyone
             # and use the first found time, if non is found, return `None`

--- a/bot/database/permissions.py
+++ b/bot/database/permissions.py
@@ -85,7 +85,7 @@ class Permissions(DBTable):
             identifier = guild.get_member(user.id)
 
         if isinstance(identifier, Member):
-            if identifier.guild_permissions().administrator:
+            if identifier.guild_permissions.administrator:
                 return None
 
             # Follow role hierarchy from most important role to everyone

--- a/bot/database/roles.py
+++ b/bot/database/roles.py
@@ -54,7 +54,7 @@ class Roles(DBTable):
         await self.db_upsert(
             columns=["serverid", role_name],
             values=[guild, role],
-            conflict_column="serverid"
+            conflict_columns=["serverid"]
         )
         self.update_cache(guild.id, role_name, role.id)
 

--- a/bot/database/roles.py
+++ b/bot/database/roles.py
@@ -56,7 +56,7 @@ class Roles(DBTable):
             values=[guild, role],
             conflict_columns=["serverid"]
         )
-        self.update_cache(guild.id, role_name, role.id)
+        self.cache_update(guild, role_name, role)
 
     def _get_role(self, role_name: str, guild: t.Union[Guild, int]) -> int:
         """Get a `role_name` column for specific `guild` from cache."""

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -24,6 +24,7 @@ def stringify_reldelta(rel_delta: relativedelta, min_unit: str = "seconds") -> s
     you'd get:
     `1 year 2 months 2 weeks and 5 days`
     """
+    rel_delta = rel_delta.normalized()
     time_dict = {
         "years": rel_delta.years,
         "months": rel_delta.months,
@@ -76,7 +77,8 @@ def stringify_timedelta(time_delta: timedelta, min_unit: str = "seconds") -> str
     you'd get:
     `1 year 2 months 2 weeks and 5 days`
     """
-    rel_delta = relativedelta(microseconds=time_delta.total_seconds() * 1000000)
+    now = datetime.now()
+    rel_delta = relativedelta(now + time_delta, now)
     return stringify_reldelta(rel_delta, min_unit=min_unit)
 
 
@@ -100,7 +102,8 @@ def stringify_duration(duration: int, min_unit: str = "seconds") -> str:
     you'd get:
     `1 year 2 months 2 weeks and 5 days`
     """
-    rel_delta = relativedelta(microseconds=duration * 1000000)
+    now = datetime.now()
+    rel_delta = relativedelta(now + timedelta(seconds=duration), now)
     return stringify_reldelta(rel_delta, min_unit=min_unit)
 
 

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -80,6 +80,30 @@ def stringify_timedelta(time_delta: timedelta, min_unit: str = "seconds") -> str
     return stringify_reldelta(rel_delta, min_unit=min_unit)
 
 
+def stringify_duration(duration: int, min_unit: str = "seconds") -> str:
+    """
+    Convert `duration` in seconds into a readable time string
+
+    `min_unit` is used to specify the printed precision,
+    aviable precision levels are:
+    * `years`
+    * `months`
+    * `weeks`
+    * `days`
+    * `hours`
+    * `minutes`
+    * `seconds`
+    * `microseconds`
+    These let you determine which unit will be the last one,
+    for example with precision of `days` from:
+    `1 year 2 months 2 weeks 5 days 4 hours 2 minutes and 1 second`
+    you'd get:
+    `1 year 2 months 2 weeks and 5 days`
+    """
+    rel_delta = relativedelta(microseconds=duration * 1000000)
+    return stringify_reldelta(rel_delta, min_unit=min_unit)
+
+
 def time_elapsed(_from: datetime, to: t.Optional[datetime] = None, min_unit: str = "seconds") -> str:
     """
     Returns how much time has elapsed in a readable string


### PR DESCRIPTION
## Summary

This PR introduces a lot of things, most notably the setup commands which serve as a way for users to communicate with the database and set the necessary values using simple commands. This also introduces a brand new table called `permissions` to manage individual permissions for each role in a given guild.

## Detailed changes

### Permissions table

I've added a new `permissions` table to hold per-role permissions which will be configurable by server administrators. This table holds these columns: `serverid`, `role`, `bantime`, `mutetime`, `locktime`.
`serverid` and `role` together are unique columns and hold the 3 actually permission columns.
These permission columns represent the maximum time for which the given role can apply ban/mute/channel lock.

The table itself holds basic setter functions (similarly to roles DBTable) but it's getter functions are a little more unique. They accept a variety of possible types for `identifier` parameter: `Member`, `Role`, `int`. 
- In case `int` was specified, the function will check whether it is a valid user id, if it isn't it will assume it's a role and get the corresponding DB values. If it is, it will find that user as a member of a given guild and continue with this `identifier` parameter set to that member.
- In case `Member` was specified it will first check if that member is an administrator. If he is, it will return `-1` (representing infinite time), if it isn't it will walk through the roles of that member from the highest in hierarchy up to everyone and use the first set permission
- In case `Role` was specified, it will simply get the corresponding DB values

### Setup commands

I've added a new directory inside of the `cogs` folder called `setup` which holds all the setup cogs and should hold all future setup cogs. Currently, it holds 2 setup cogs, `roles` and `permissions`, each managing a separate database (suggested by filename).
These cogs hold multiple setter fucntions and a single getter function.

I could get into more details as to which exact commands are included, but these are just the basic fairly intuitive fucntions and it can be easily seen from the code of these cogs.

## Non-related changes

This PR also introduces some bug fixes and other non-directly related additions to the code base, I fixed these issues here since I couldn't proceed without doing so. Because of these fixes, I've assigned high priority to this PR.

Changes made:
- Fixed malfunctioning db cache system (initial cache loading didn't work properly)
- Fixed `bot/util/time.py` functions to make relative deltas from 2 datetimes rather than by specifying time directly. Doing this gives us the ability to show months and years rather than being limited to maximum units of weeks
- Added ability to have multiple conflict columns (passed in a list) for `db_upsert` method (in `DBTable` class)
- Fix some spelling issues in `CONTRIBUTING.md`
- Rename references to the `update_cache` function to `cache_update` (this function was renamed in a PR that introduced it but 2 references to it were left unchanged, this wasn't noticed in PR review and it got merged. This PR fixes those references.
- Add a possibility to use infinite time with a duration converter