### PR TITLE
Add error handler

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -13,7 +13,8 @@ extensions = [
     "bot.cogs.setup.roles",
     "bot.cogs.setup.permissions",
     "bot.cogs.sudo",
-    "bot.cogs.embeds"
+    "bot.cogs.embeds",
+    "bot.cogs.error_handler"
 ]
 db_tables = [
     "bot.database.roles",

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -79,6 +79,8 @@ class ErrorHandler(Cog):
                 return
 
             await self.send_unhandled_embed(ctx, original_exception)
+            # Raise the original exception to show the traceback
+            raise original_exception
             return
 
         await self.send_unhandled_embed(ctx, exception)

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -3,7 +3,7 @@ import typing as t
 from json import JSONDecodeError
 
 from discord import Color, Embed
-from discord.ext.commands import Cog, Context, errors
+from discord.ext.commands import Cog, Context, NotOwner, errors
 from loguru import logger
 
 from bot.cogs.embeds import InvalidEmbed
@@ -115,9 +115,13 @@ class ErrorHandler(Cog):
         )
 
     async def handle_check_failure(self, ctx: Context, exception: errors.CheckFailure) -> None:
+        if isinstance(exception, NotOwner):
+            msg = "❌ This command is only aviable to bot owners."
+        else:
+            msg = "❌ You don't have permission to run this command."
         await self._send_error_embed(
             ctx,
-            description="❌ You don't have permission to run this command"
+            description=msg
         )
 
     async def handle_json_decode_error(self, ctx: Context, exception: JSONDecodeError) -> None:

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -63,7 +63,8 @@ class ErrorHandler(Cog):
             await self.handle_user_input_error(ctx, exception)
             return
         elif isinstance(exception, errors.CommandNotFound):
-            await self.handle_command_not_found(ctx, exception)
+            # Ignore command not found due to possibility of other bots with the
+            # same command prefix
             return
         elif isinstance(exception, errors.CheckFailure):
             await self.handle_check_failure(ctx, exception)
@@ -110,9 +111,6 @@ class ErrorHandler(Cog):
                 """
             )
         )
-
-    async def handle_command_not_found(self, ctx: Context, exception: errors.CommandNotFound) -> None:
-        await self.send_unhandled_embed(ctx, exception)
 
     async def handle_check_failure(self, ctx: Context, exception: errors.CheckFailure) -> None:
         await self.send_unhandled_embed(ctx, exception)

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -113,7 +113,10 @@ class ErrorHandler(Cog):
         )
 
     async def handle_check_failure(self, ctx: Context, exception: errors.CheckFailure) -> None:
-        await self.send_unhandled_embed(ctx, exception)
+        await self._send_error_embed(
+            ctx,
+            description="❌ You don't have permission to run this command"
+        )
 
     async def handle_json_decode_error(self, ctx: Context, exception: JSONDecodeError) -> None:
         msg = textwrap.dedent(

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -53,7 +53,11 @@ class ErrorHandler(Cog):
         1. `UserInputError`: references `handle_user_input_error`
         2. `CommandNotFound`: references `handle_command_not_found`
         3. `CheckFailure`: references `handle_command_not_found`
-        4. Otherwise, send unhandled error embed with `send_unhandled_embed`
+        4. `CommandInvokeError`: this error is raised when any unknown exception
+        was raised in a command, it references `send_unhandled_embed` with the specific
+        exception which has occurred in the command in case it doesn't match the more
+        specific filters.
+        5. Otherwise, send unhandled error embed with `send_unhandled_embed`
         """
         if isinstance(exception, errors.UserInputError):
             await self.handle_user_input_error(ctx, exception)

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -83,7 +83,33 @@ class ErrorHandler(Cog):
         await self.send_unhandled_embed(ctx, exception)
 
     async def handle_user_input_error(self, ctx: Context, exception: errors.UserInputError) -> None:
-        await self.send_unhandled_embed(ctx, exception)
+        command = ctx.command
+        parent = command.full_parent_name
+
+        command_name = str(command) if not parent else f"{parent} {command.name}"
+        command_syntax = f"```{command_name} {command.signature}```"
+
+        aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases]
+        aliases = ", ".join(sorted(aliases))
+
+        command_help = f"*{command.help or 'No description provided.'}*"
+
+        await self._send_error_embed(
+            ctx,
+            title="Invalid command syntax",
+            description=textwrap.dedent(
+                f"""
+                Your command usage is incorrect: **{exception}**
+
+                **Command syntax**
+                {command_syntax}
+                **Command Description**
+                {command_help}
+
+                {f"Aliases: {aliases}" if aliases else None}
+                """
+            )
+        )
 
     async def handle_command_not_found(self, ctx: Context, exception: errors.CommandNotFound) -> None:
         await self.send_unhandled_embed(ctx, exception)
@@ -106,7 +132,7 @@ class ErrorHandler(Cog):
                 f"""
                 ```
                 {exception.lines[exception.lineno - 1]}
-                {"" * (int(exception.colno) - 1)}^
+                {" " * (int(exception.colno) - 1)}^
                 ```
                 """
             )

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -1,0 +1,33 @@
+import typing as t
+
+from discord import Color, Embed
+from discord.ext.commands import Cog, Context, errors
+from loguru import logger
+
+from bot.core.bot import Bot
+
+
+class ErrorHandler(Cog):
+    """This cog handles the errors invoked from commands."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    async def send_error_embed(self, ctx: Context, title: t.Optional[str], description: t.Optional[str]) -> None:
+        embed = Embed(
+            title=title,
+            description=description,
+            color=Color.red()
+        )
+        await ctx.send(embed=embed)
+
+    @Cog.listener()
+    async def on_command_error(self, ctx: Context, exception: errors.CommandError) -> None:
+        logger.debug(
+            f"Exception {exception.__class__.__name__}: {exception} has occurred in "
+            f" command {ctx.command} invoked by {ctx.author.id} on {ctx.guild.id}"
+        )
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(ErrorHandler(bot))

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -24,8 +24,8 @@ class ErrorHandler(Cog):
 
     async def send_unhandled_embed(self, ctx: Context, exception: errors.CommandError) -> None:
         logger.debug(
-            f"Exception {exception.__class__.__name__}: {exception} has occurred in "
-            f" command {ctx.command} invoked by {ctx.author.id} on {ctx.guild.id}"
+            f"Exception {exception.__class__.__name__}: {exception} has occurred from "
+            f"message {ctx.message.content} invoked by {ctx.author.id} on {ctx.guild.id}"
         )
         await self._send_error_embed(
             ctx,
@@ -45,7 +45,35 @@ class ErrorHandler(Cog):
 
     @Cog.listener()
     async def on_command_error(self, ctx: Context, exception: errors.CommandError) -> None:
+        """
+        Handle exceptions which occurred while running some command.
+
+        The error handle order is as follows:
+        1. `UserInputError`: references `handle_user_input_error`
+        2. `CommandNotFound`: references `handle_command_not_found`
+        3. `CheckFailure`: references `handle_command_not_found`
+        4. Otherwise, send unhandled error embed with `send_unhandled_embed`
+        """
+        if isinstance(exception, errors.UserInputError):
+            await self.handle_user_input_error(ctx, exception)
+            return
+        elif isinstance(exception, errors.CommandNotFound):
+            await self.handle_command_not_found(ctx, exception)
+            return
+        elif isinstance(exception, errors.CheckFailure):
+            await self.handle_check_failure(ctx, exception)
+            return
+
         await self.send_unhandled_embed(ctx, exception)
+
+    async def handle_user_input_error(self, ctx: Context, exception: errors.UserInputError) -> None:
+        pass
+
+    async def handle_command_not_found(self, ctx: Context, exception: errors.CommandNotFound) -> None:
+        pass
+
+    async def handle_check_failure(self, ctx: Context, exception: errors.CheckFailure) -> None:
+        pass
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -25,7 +25,7 @@ class ErrorHandler(Cog):
         await ctx.send(embed=embed)
 
     async def send_unhandled_embed(self, ctx: Context, exception: errors.CommandError) -> None:
-        logger.debug(
+        logger.warning(
             f"Exception {exception.__repr__()} has occurred from "
             f"message {ctx.message.content} invoked by {ctx.author.id} on {ctx.guild.id}"
         )

--- a/bot/cogs/sudo.py
+++ b/bot/cogs/sudo.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from discord import Color, DiscordException, Embed
 from discord import __version__ as discord_version
-from discord.ext.commands import Cog, Context, group
+from discord.ext.commands import Cog, Context, NotOwner, group
 
 from bot import config
 from bot.core.bot import Bot
@@ -100,12 +100,12 @@ class Sudo(Cog):
 
         await ctx.send(embed=embed)
 
-    async def cog_check(self, ctx: Context) -> t.Union[bool, None]:
+    async def cog_check(self, ctx: Context) -> t.Optional[bool]:
         """Only the bot owners can use this."""
         if ctx.author.id in config.devs:
             return True
 
-        return False
+        raise NotOwner
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/sudo.py
+++ b/bot/cogs/sudo.py
@@ -105,12 +105,6 @@ class Sudo(Cog):
         if ctx.author.id in config.devs:
             return True
 
-        await ctx.send(
-            embed=Embed(
-                description="❌ Sorry, this command is reserved for bot owners",
-                color=Color.red()
-            )
-        )
         return False
 
 


### PR DESCRIPTION
## Summary

This adds an error handler cog which holds `on_command_error` listener. This listener is ran every time a `CommandError` is raised. Currently, all raised errors are simply being ignored and the user has no way of knowing whether some error has occurred and what was the error. This error handler informs user about the exception which has ocurred, in case this specific exception doesn't have a custom handling built specifically for it, it sends a warning log with exception details and an embed to inform user about the unhandled exception with proper links to the bot repository, where they can report these errors.

## Created Handlers

I've implemented multiple handlers, this is the list of them:

### UserInputError

This error is raised whenever a user uses the command improperly (i.e. wrong amount of arguments, bad argument, etc.)
It sends user an embed informing him about the error details.
<details>

<summary>
Embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96386285-f996a500-1199-11eb-8a77-85aee6467ee9.png)

</p>
</details>

### CommandNotFound

This error is fairly descriptive, it is raised when a user enters an unknown command.
In this case, no embed is sent since there's a possibility multiple bots are in use with the same prefix and sending unknown command error might be irritating when the command actually is valid, but it's from a different bot.

### CheckFailure

This error is raised whenever a check for certain command fails, for example, if the command can only be run with specific permission, which the user doesn't have.

<details>

<summary>
Embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96386619-96f2d880-119c-11eb-834c-2875df346af9.png)

</p>
</details>

I've also included a special case for `discord.ext.commands.NotOwner` instance


<details>

<summary>
Special case embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96453341-9d279a00-121a-11eb-8361-9c35096b6773.png)

</p>
</details>

### CommandInvokeError

This error is raised whenever a command raises any exception directly, the original exception is stored in `exception.__cause__` which is then used to perform further checks:

**`JSONDecodeError`**
This error is raised when the JSON module can't decode a string into json (python dict) format.

<details>

<summary>
Embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96386400-fd76f700-119a-11eb-8848-65c7412a4018.png)

</p>
</details>

**`InvalidEmbed`**
This error is raised when the user-made embed in the embed-handler is invalid.

<details>

<summary>
Embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96386432-40d16580-119b-11eb-9a2a-1f7e56d11525.png)

</p>
</details>

**Other exception**
Any other exception falls back to an unhandled exception, but the original exception (from the command) is passed, rather than the `CommandInvokeError` one. After that this exception is also manually raised again from the error handler in order to provide a proper traceback for it.

### Unhandled exception

Whenever the exception doesn't have a built handler, it falls back here, in that case, an embed and warn level log message are sent.

<details>

<summary>
Embed photo
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96386710-3c0db100-119d-11eb-92e4-fed1c43026db.png)

</p>
</details>
