### PR TITLE
Slowmode

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -9,12 +9,13 @@ TOKEN = os.getenv("BOT_TOKEN")
 PREFIX = config.COMMAND_PREFIX
 
 extensions = [
+    "bot.cogs.error_handler",
+    "bot.cogs.sudo",
     "bot.cogs.moderation.lock",
+    "bot.cogs.moderation.slowmode",
     "bot.cogs.setup.roles",
     "bot.cogs.setup.permissions",
-    "bot.cogs.sudo",
     "bot.cogs.embeds",
-    "bot.cogs.error_handler"
 ]
 db_tables = [
     "bot.database.roles",

--- a/bot/cogs/moderation/lock.py
+++ b/bot/cogs/moderation/lock.py
@@ -61,7 +61,7 @@ class Lock(Cog):
         return True
 
     @command(aliases=["silence"])
-    async def lock(self, ctx: Context = None, duration: t.Optional[Duration] = None, *, reason: t.Optional[str]) -> None:
+    async def lock(self, ctx: Context, duration: t.Optional[Duration] = None, *, reason: t.Optional[str]) -> None:
         """
         Disallow everyones permission to talk in this channel
         for given `duration` or indefinitely.

--- a/bot/cogs/moderation/lock.py
+++ b/bot/cogs/moderation/lock.py
@@ -2,7 +2,6 @@ import asyncio
 import typing as t
 from collections import defaultdict
 
-from dateutil.relativedelta import relativedelta
 from discord import TextChannel
 from discord.ext.commands import Cog, Context, MissingPermissions, command
 from loguru import logger
@@ -12,7 +11,7 @@ from bot.core.converters import Duration
 from bot.core.timer import Timer
 from bot.database.permissions import Permissions
 from bot.database.roles import Roles
-from bot.utils.time import stringify_reldelta
+from bot.utils.time import stringify_duration
 
 
 class Lock(Cog):
@@ -89,7 +88,7 @@ class Lock(Cog):
             await ctx.send(f"🔒 Channel locked indefinitely: {reason}.")
             return
 
-        await ctx.send(f"🔒 Channel locked for {stringify_reldelta(relativedelta(seconds=duration))}: {reason}.")
+        await ctx.send(f"🔒 Channel locked for {stringify_duration(duration)}: {reason}.")
         self.timer.delay(duration, ctx.channel.id, ctx.invoke(self.unlock))
 
     @command(aliases=["unsilence"])

--- a/bot/cogs/moderation/slowmode.py
+++ b/bot/cogs/moderation/slowmode.py
@@ -35,7 +35,7 @@ class Slowmode(Cog):
 
     async def cog_check(self, ctx: Context) -> bool:
         """
-        Only allow users with manage messages permission to use these function.
+        Only allow users with manage channels permission to use these function.
 
         Also make sure there's a default role set for that server.
         In case there isn't, send an error message.

--- a/bot/cogs/moderation/slowmode.py
+++ b/bot/cogs/moderation/slowmode.py
@@ -1,0 +1,50 @@
+from discord.ext.commands import BadArgument, Cog, Context, command
+from loguru import logger
+
+from bot.core.bot import Bot
+from bot.core.converters import Duration
+from bot.utils.time import stringify_duration
+
+
+class Lock(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @command(aliases=["slowmode"])
+    async def slow_mode(self, ctx: Context, duration: Duration) -> None:
+        """
+        Apply slow mode on channel the command was invoked from.
+
+        Maximum duration for slowmode is 6 hours (discords limitation)
+        Using 0 for duration will turn off the slowmode
+        """
+        if duration > 6 * 60 * 60:  # maximum of 6 hours
+            raise BadArgument("Maximum duration is 6 hours")
+
+        await ctx.channel.edit(slowmode_delay=duration)
+
+        if duration:
+            log_msg = f"ser {ctx.author} applied slowmode to #{ctx.channel} for {stringify_duration(duration)}"
+            msg = f"⏱️ Applied slowmode for this channel, time delay: {stringify_duration(duration)}."
+        else:
+            log_msg = f"User {ctx.author} removed slowmode from #{ctx.channel}"
+            msg = "💬 Slowmode removed."
+
+        logger.debug(log_msg)
+        await ctx.send(msg)
+
+    async def cog_check(self, ctx: Context) -> bool:
+        """
+        Only allow users with manage messages permission to use these function.
+
+        Also make sure there's a default role set for that server.
+        In case there isn't, send an error message.
+        """
+        if ctx.author.permissions_in(ctx.channel).manage_channels:
+            return True
+
+        return False
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(Lock(bot))

--- a/bot/cogs/moderation/slowmode.py
+++ b/bot/cogs/moderation/slowmode.py
@@ -6,7 +6,7 @@ from bot.core.converters import Duration
 from bot.utils.time import stringify_duration
 
 
-class Lock(Cog):
+class Slowmode(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
@@ -47,4 +47,4 @@ class Lock(Cog):
 
 
 def setup(bot: Bot) -> None:
-    bot.add_cog(Lock(bot))
+    bot.add_cog(Slowmode(bot))

--- a/bot/cogs/sudo.py
+++ b/bot/cogs/sudo.py
@@ -12,7 +12,7 @@ from discord.ext.commands import Cog, Context, NotOwner, group
 
 from bot import config
 from bot.core.bot import Bot
-from bot.utils import time as tm
+from bot.utils.time import stringify_timedelta
 
 
 class Sudo(Cog):
@@ -81,7 +81,7 @@ class Sudo(Cog):
             • Servers: **`{len(self.bot.guilds)}`**
             • Commands: **`{len(self.bot.commands)}`**
             • Members: **`{len(set(self.bot.get_all_members()))}`**
-            • Uptime: **{tm.stringify_reldelta(datetime.utcnow() - self.bot.start_time)}**
+            • Uptime: **{stringify_timedelta(datetime.utcnow() - self.bot.start_time)}**
             """
         )
         system = textwrap.dedent(
@@ -96,7 +96,7 @@ class Sudo(Cog):
         embed.add_field(name="**❯❯ System**", value=system, inline=True)
 
         embed.set_author(name=f"{self.bot.user.name}'s Stats", icon_url=self.bot.user.avatar_url)
-        embed.set_footer(text=f"Made by {config.creator} Team.")
+        embed.set_footer(text=f"Made by {config.creator}.")
 
         await ctx.send(embed=embed)
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -5,7 +5,7 @@ import os
 DEV_MODE = True
 
 # Ownership settings:
-creator = "The Codin Team"
+creator = "The Codin Nerds Team"
 devs = [711194921683648523, 306876636526280705]
 
 # Database

--- a/bot/core/converters.py
+++ b/bot/core/converters.py
@@ -127,14 +127,23 @@ class TimeDelta(Converter):
 class Duration(TimeDelta):
     """Convert duration strings into amount of seconds"""
 
-    async def convert(self, ctx: Context, duration: str) -> int:
+    async def convert(self, ctx: Context, duration: str) -> t.Union[int, float]:
         """
         Convert a `duration` string into a relativedelta using
         super `TimeDelta` converter. After that, simply change
         the relative delta into the amount of seconds it represents.
+
+        Accepted inputs (in order):
+        * infinity inputs: `-1`, `inf`, `infinity`, `infinite`
+        * zero inputs: `0`, `none`, `null`
+        * `TimeDelta` converter inputs
         """
+        duration = duration.lower()
+
         if duration in ["-1", "inf", "infinite", "infinity"]:
             return float("inf")
+        if duration in ["0", "none", "null"]:
+            return 0
 
         delta = await super().convert(ctx, duration)
 

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -82,7 +82,7 @@ def stringify_timedelta(time_delta: timedelta, min_unit: str = "seconds") -> str
     return stringify_reldelta(rel_delta, min_unit=min_unit)
 
 
-def stringify_duration(duration: int, min_unit: str = "seconds") -> str:
+def stringify_duration(duration: t.Union[int, float], min_unit: str = "seconds") -> str:
     """
     Convert `duration` in seconds into a readable time string
 
@@ -102,6 +102,11 @@ def stringify_duration(duration: int, min_unit: str = "seconds") -> str:
     you'd get:
     `1 year 2 months 2 weeks and 5 days`
     """
+    if isinstance(duration, float):
+        if duration == float("inf"):
+            return "infinity"
+        duration = round(duration)
+
     now = datetime.now()
     rel_delta = relativedelta(now + timedelta(seconds=duration), now)
     return stringify_reldelta(rel_delta, min_unit=min_unit)

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -105,7 +105,6 @@ def stringify_duration(duration: t.Union[int, float], min_unit: str = "seconds")
     if isinstance(duration, float):
         if duration == float("inf"):
             return "infinity"
-        duration = round(duration)
 
     now = datetime.now()
     rel_delta = relativedelta(now + timedelta(seconds=duration), now)


### PR DESCRIPTION
Add slow mode command, available to anyone with manage channel permissions.
This is very useful for setting slow mode times without relying on discords duration limitations (i.e by default. you can't set the slow mode to 1.5hours, only to 1 or 2 hours).