### PR TITLE
Add help command

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ autopep8 = "~=1.5.4"
 loguru = "~=0.5.3"
 python-dateutil = "~=2.8.1"
 "discord.py" = "~=1.5"
+discord-ext-menus = {git="https://github.com/Rapptz/discord-ext-menus"}
 asyncpg = "~=0.21.0"
 
 [scripts]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f49c51b106391b72965def5f45a2aa7a9d202dfcb8c641c8deaf28d7527a5991"
+            "sha256": "8c94c12a82a668062b41b1a09c0619e69819be8903f8bb8951c212af5cc5c58b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,20 +18,21 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e",
-                "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326",
-                "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a",
-                "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654",
-                "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a",
-                "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4",
-                "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17",
-                "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec",
-                "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd",
-                "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48",
-                "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59",
-                "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"
+                "sha256:1a4160579ffbc1b69e88cb6ca8bb0fbd4947dfcbf9fb1e2a4fc4c7a4a986c1fe",
+                "sha256:206c0ccfcea46e1bddc91162449c20c72f308aebdcef4977420ef329c8fcc599",
+                "sha256:2ad493de47a8f926386fa6d256832de3095ba285f325db917c7deae0b54a9fc8",
+                "sha256:319b490a5e2beaf06891f6711856ea10591cfe84fe9f3e71a721aa8f20a0872a",
+                "sha256:470e4c90da36b601676fe50c49a60d34eb8c6593780930b1aa4eea6f508dfa37",
+                "sha256:60f4caa3b7f7a477f66ccdd158e06901e1d235d572283906276e3803f6b098f5",
+                "sha256:66d64486172b032db19ea8522328b19cfb78a3e1e5b62ab6a0567f93f073dea0",
+                "sha256:687461cd974722110d1763b45c5db4d2cdee8d50f57b00c43c7590d1dd77fc5c",
+                "sha256:698cd7bc3c7d1b82bb728bae835724a486a8c376647aec336aa21a60113c3645",
+                "sha256:797456399ffeef73172945708810f3277f794965eb6ec9bd3a0c007c0476be98",
+                "sha256:a885432d3cabc1287bcf88ea94e1826d3aec57fd5da4a586afae4591b061d40d",
+                "sha256:c506853ba52e516b264b106321c424d03f3ddef2813246432fa9d1cefd361c81",
+                "sha256:fb83326d8295e8840e4ba774edf346e87eca78ba8a89c55d2690352842c15ba5"
             ],
-            "version": "==3.6.2"
+            "version": "==3.6.3"
         },
         "async-timeout": {
             "hashes": [
@@ -84,6 +85,10 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "discord-ext-menus": {
+            "git": "https://github.com/Rapptz/discord-ext-menus",
+            "ref": "84caae8038d0d3adc860957ccef05baeec2e2dd8"
         },
         "discord.py": {
             "hashes": [
@@ -147,25 +152,25 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:04a54f126a0732af75e5edc9addeaa2113e2ca7c6fce8974a63549a70a25e50e",
-                "sha256:3cc860d72ed989f3b1f3abbd6ecf38e412de722fb38b8f1b1a086315cf0d69c5",
-                "sha256:5d84cc36981eb5a8533be79d6c43454c8e6a39ee3118ceaadbd3c029ab2ee580",
-                "sha256:5e447e7f3780f44f890360ea973418025e8c0cdcd7d6a1b221d952600fd945dc",
-                "sha256:61d3ea3c175fe45f1498af868879c6ffeb989d4143ac542163c45538ba5ec21b",
-                "sha256:67c5ea0970da882eaf9efcf65b66792557c526f8e55f752194eff8ec722c75c2",
-                "sha256:6f6898429ec3c4cfbef12907047136fd7b9e81a6ee9f105b45505e633427330a",
-                "sha256:7ce35944e8e61927a8f4eb78f5bc5d1e6da6d40eadd77e3f79d4e9399e263921",
-                "sha256:b7c199d2cbaf892ba0f91ed36d12ff41ecd0dde46cbf64ff4bfe997a3ebc925e",
-                "sha256:c15d71a640fb1f8e98a1423f9c64d7f1f6a3a168f803042eaf3a5b5022fde0c1",
-                "sha256:c22607421f49c0cb6ff3ed593a49b6a99c6ffdeaaa6c944cdda83c2393c8864d",
-                "sha256:c604998ab8115db802cc55cb1b91619b2831a6128a62ca7eea577fc8ea4d3131",
-                "sha256:d088ea9319e49273f25b1c96a3763bf19a882cff774d1792ae6fba34bd40550a",
-                "sha256:db9eb8307219d7e09b33bcb43287222ef35cbcf1586ba9472b0a4b833666ada1",
-                "sha256:e31fef4e7b68184545c3d68baec7074532e077bd1906b040ecfba659737df188",
-                "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020",
-                "sha256:fcbe419805c9b20db9a51d33b942feddbf6e7fb468cb20686fd7089d4164c12a"
+                "sha256:040b237f58ff7d800e6e0fd89c8439b841f777dd99b4a9cca04d6935564b9409",
+                "sha256:17668ec6722b1b7a3a05cc0167659f6c95b436d25a36c2d52db0eca7d3f72593",
+                "sha256:3a584b28086bc93c888a6c2aa5c92ed1ae20932f078c46509a66dce9ea5533f2",
+                "sha256:4439be27e4eee76c7632c2427ca5e73703151b22cae23e64adb243a9c2f565d8",
+                "sha256:48e918b05850fffb070a496d2b5f97fc31d15d94ca33d3d08a4f86e26d4e7c5d",
+                "sha256:9102b59e8337f9874638fcfc9ac3734a0cfadb100e47d55c20d0dc6087fb4692",
+                "sha256:9b930776c0ae0c691776f4d2891ebc5362af86f152dd0da463a6614074cb1b02",
+                "sha256:b3b9ad80f8b68519cc3372a6ca85ae02cc5a8807723ac366b53c0f089db19e4a",
+                "sha256:bc2f976c0e918659f723401c4f834deb8a8e7798a71be4382e024bcc3f7e23a8",
+                "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6",
+                "sha256:c52ce2883dc193824989a9b97a76ca86ecd1fa7955b14f87bf367a61b6232511",
+                "sha256:ce584af5de8830d8701b8979b18fcf450cef9a382b1a3c8ef189bedc408faf1e",
+                "sha256:da456eeec17fa8aa4594d9a9f27c0b1060b6a75f2419fe0c00609587b2695f4a",
+                "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb",
+                "sha256:df89642981b94e7db5596818499c4b2219028f2a528c9c37cc1de45bf2fd3a3f",
+                "sha256:f18d68f2be6bf0e89f1521af2b1bb46e66ab0018faafa81d70f358153170a317",
+                "sha256:f379b7f83f23fe12823085cd6b906edc49df969eb99757f58ff382349a3303c6"
             ],
-            "version": "==1.6.0"
+            "version": "==1.5.1"
         }
     },
     "develop": {
@@ -227,11 +232,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c",
-                "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
             ],
             "index": "pypi",
-            "version": "==3.8.3"
+            "version": "==3.8.4"
         },
         "flake8-annotations": {
             "hashes": [
@@ -259,10 +264,10 @@
         },
         "identify": {
             "hashes": [
-                "sha256:7c22c384a2c9b32c5cc891d13f923f6b2653aa83e2d75d8f79be240d6c86c4f4",
-                "sha256:da683bfb7669fa749fc7731f378229e2dbf29a1d1337cbde04106f02236eb29d"
+                "sha256:3139bf72d81dfd785b0a464e2776bd59bdc725b4cc10e6cf46b56a0db931c82e",
+                "sha256:969d844b7a85d32a5f9ac4e163df6e846d73c87c8b75847494ee8f4bd2186421"
             ],
-            "version": "==1.5.5"
+            "version": "==1.5.6"
         },
         "ipython": {
             "hashes": [
@@ -332,10 +337,10 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:822f4605f28f7d2ba6b0b09a31e25e140871e96364d1d377667b547bb3bf4489",
-                "sha256:83074ee28ad4ba6af190593d4d4c607ff525272a504eb159199b6dd9f950c950"
+                "sha256:25c95d2ac813909f813c93fde734b6e44406d1477a9faef7c915ff37d39c0a8c",
+                "sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63"
             ],
-            "version": "==3.0.7"
+            "version": "==3.0.8"
         },
         "ptyprocess": {
             "hashes": [
@@ -397,17 +402,17 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:86c9351f94f95de9db8a04ad8e892da299a088a64fd283f9f6f18770ae5eae1b",
-                "sha256:9664ec0c526e48e7b47b7d14cd6b252efa03e0129011de0a9c1d70315d4309c3"
+                "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396",
+                "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"
             ],
-            "version": "==5.0.4"
+            "version": "==5.0.5"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc",
-                "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"
+                "sha256:0ebc633426d7468664067309842c81edab11ae97fcaf27e8ad7f5748c89b431b",
+                "sha256:2a72c80fa2ad8f4e2985c06e6fc12c3d60d060e410572f553c90619b0f6efaf3"
             ],
-            "version": "==20.0.31"
+            "version": "==20.0.35"
         },
         "wcwidth": {
             "hashes": [

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -14,7 +14,8 @@ extensions = [
     "bot.cogs.setup.permissions",
     "bot.cogs.sudo",
     "bot.cogs.embeds",
-    "bot.cogs.error_handler"
+    "bot.cogs.error_handler",
+    "bot.cogs.help"
 ]
 db_tables = [
     "bot.database.roles",

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -130,7 +130,7 @@ class Embeds(Cog):
     @group(invoke_without_command=True, name="embed", aliases=["embedset", "set_embed"])
     async def embed_group(self, ctx: Context) -> None:
         """Commands for configuring the Embed messages."""
-        await ctx.send("This command is not meant to be used on its own!")
+        await ctx.send_help(ctx.command)
 
     # region: basic embed settings (title, description, footer, image, color, message)
 

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -144,6 +144,16 @@ class HelpCommand(BaseHelpCommand):
         super().__init__(command_attrs={"help": "Shows help for given command / all commands"})
 
     async def _describe_command(self, command: Command) -> t.Tuple[str, str, str, str]:
+        """
+        Describe command in a meaningful syntax which can than be showed to
+        users to provide details about given command.
+
+        Returns a tuple of these variabels:
+        1. `command_name`: the exact syntex (without prefix) used to call the command
+        2. `command_syntax`: contains the command name with prefix and the values command takes
+        3. `command_help`: the help docstring from given command
+        4. `aliases`: all aliases the command has, separated by comma
+        """
         if not await command.can_run(self.context):
             raise CheckFailure("You don't have permission to view help for this command.")
 

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -268,6 +268,13 @@ class HelpCommand(BaseHelpCommand):
         if length > MAX_CHARACTERS:
             return HelpPages.split_cog_commands(fields, initial_embed=embed)
 
+        for fld in fields:
+            embed.add_field(
+                name=fld.name,
+                value=fld.value,
+                inline=False
+            )
+
         return embed
 
     async def send_bot_help(self, mapping: t.Dict[t.Optional[Cog], t.List[Command]]) -> None:

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,0 +1,67 @@
+import textwrap
+
+from discord import Color, Embed
+from discord.ext.commands import Cog, Command, HelpCommand as OriginalHelpCommand
+
+from bot.core.bot import Bot
+
+
+class HelpCommand(OriginalHelpCommand):
+    """The help command implementation."""
+
+    def __init__(self):
+        super().__init__(command_attrs={"help": "Shows help for given command / all commands"})
+
+    async def fromat_command(self, command: Command) -> str:
+        """Format a help message for given `command`."""
+        parent = command.full_parent_name
+
+        command_name = str(command) if not parent else f"{parent} {command.name}"
+        command_syntax = f"{self.context.prefix}{command_name} {command.signature}"
+
+        aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases]
+        aliases = ", ".join(sorted(aliases))
+
+        command_help = f"{command.help or 'No description provided.'}"
+
+        message = textwrap.dedent(
+            f"""
+            Help syntax: `<Required arguments>`, `[Optional arguments]`
+
+            **Syntax for {command_name}**:
+            ```{command_syntax}```
+            **Command description**
+            *{command_help}*
+            """
+        )
+
+        if aliases:
+            message += f"\n\nAliases: {aliases}"
+        if not await command.can_run(self.context):
+            message += "**You don't have permission to use this command.**"
+
+        return message
+
+    async def send_command_help(self, command: Command) -> None:
+        msg = await self.fromat_command(command)
+        embed = Embed(
+            title="Command Help",
+            description=msg,
+            color=Color.blue()
+        )
+        await self.context.send(embed=embed)
+        # TODO: Schedule deletion
+
+
+class Help(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.old_help_command = bot.help_command
+        bot.help_command = HelpCommand()
+
+    def cog_unload(self) -> None:
+        self.bot.help_command = self.old_help_command
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(Help(bot))

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -3,6 +3,7 @@ import typing as t
 
 from discord import Color, Embed
 from discord.ext.commands import Cog, Command, Group, HelpCommand as BaseHelpCommand
+from discord.ext.commands.errors import CheckFailure
 from discord.ext.menus import ListPageSource, Menu, MenuPages
 
 from bot.core.bot import Bot
@@ -24,15 +25,14 @@ class HelpCommand(BaseHelpCommand):
         super().__init__(command_attrs={"help": "Shows help for given command / all commands"})
 
     async def _describe_command(self, command: Command) -> t.Tuple[str, str, str, str]:
+        if not await command.can_run(self.context):
+            raise CheckFailure("You don't have permission to view help for this command.")
+
         parent = command.full_parent_name
 
         command_name = str(command) if not parent else f"{parent} {command.name}"
         command_syntax = f"{self.context.prefix}{command_name} {command.signature}"
-
-        if await command.can_run(self.context):
-            command_help = f"{command.help or 'No description provided.'}"
-        else:
-            command_help = "You don't have permission to use this command."
+        command_help = f"{command.help or 'No description provided.'}"
 
         aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases]
         aliases = ", ".join(sorted(aliases))

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,9 +1,20 @@
 import textwrap
+import typing as t
 
 from discord import Color, Embed
 from discord.ext.commands import Cog, Command, HelpCommand as OriginalHelpCommand
+from discord.ext.menus import ListPageSource, Menu, MenuPages
 
 from bot.core.bot import Bot
+
+
+class HelpPages(ListPageSource):
+    def __init__(self, cog_embeds: t.List[Embed]):
+        super().__init__(cog_embeds, per_page=1)
+
+    async def format_page(self, menu: Menu, embed: Embed) -> Embed:
+        """Return the stored embed for current cog."""
+        return embed
 
 
 class HelpCommand(OriginalHelpCommand):
@@ -12,8 +23,8 @@ class HelpCommand(OriginalHelpCommand):
     def __init__(self):
         super().__init__(command_attrs={"help": "Shows help for given command / all commands"})
 
-    async def fromat_command(self, command: Command) -> str:
-        """Format a help message for given `command`."""
+    async def _fromat_command(self, command: Command) -> Embed:
+        """Format a help embed message for given `command`."""
         parent = command.full_parent_name
 
         command_name = str(command) if not parent else f"{parent} {command.name}"
@@ -22,35 +33,100 @@ class HelpCommand(OriginalHelpCommand):
         aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases]
         aliases = ", ".join(sorted(aliases))
 
-        command_help = f"{command.help or 'No description provided.'}"
+        if await command.can_run(self.context):
+            command_help = f"{command.help or 'No description provided.'}"
+        else:
+            command_help += "*You don't have permission to use this command.*"
 
-        message = textwrap.dedent(
-            f"""
-            Help syntax: `<Required arguments>`, `[Optional arguments]`
-
-            **Syntax for {command_name}**:
-            ```{command_syntax}```
-            **Command description**
-            *{command_help}*
-            """
-        )
-
-        if aliases:
-            message += f"\n\nAliases: {aliases}"
-        if not await command.can_run(self.context):
-            message += "**You don't have permission to use this command.**"
-
-        return message
-
-    async def send_command_help(self, command: Command) -> None:
-        msg = await self.fromat_command(command)
         embed = Embed(
             title="Command Help",
-            description=msg,
+            description="Help syntax: `<Required arguments>`, `[Optional arguments]`",
             color=Color.blue()
         )
+        embed.add_field(
+            name=f"Syntax for {command_name}",
+            value=f"```{command_syntax}```",
+            inline=False
+        )
+        embed.add_field(
+            name="Command description",
+            value=f"*{command_help}*",
+            inline=False
+        )
+        if aliases:
+            embed.add_field(name="Aliases", value=aliases, inline=False)
+
+        return embed
+
+    async def _format_cog(self, cog: t.Optional[Cog], commands: t.Optional[t.List[Command]] = None) -> Embed:
+        """
+        Format a help embed message for the given cog.
+
+        In case to cog is given, a help embed will be made for commands outside of any cog.
+        """
+        if cog:
+            cog_description = cog.description if cog.description else "No description provided"
+        else:
+            cog_description = ""
+
+        embed = Embed(
+            title=f"Help for {cog.qualified_name if cog else 'unclassified commands'}",
+            description=textwrap.dedent(
+                f"""
+                Help syntax: `<Required arguments>`, `[Optional arguments]`
+
+                {cog_description}
+
+                """
+            ),
+            color=Color.blue()
+        )
+
+        if commands is None:
+            commands = await self.filter_commands(cog.get_commands())
+
+        for command in commands:
+            parent = command.full_parent_name
+
+            command_name = str(command) if not parent else f"{parent} {command.name}"
+            command_syntax = f"{self.context.prefix}{command_name} {command.signature}"
+            command_help = f"{command.help or 'No description provided.'}"
+
+            embed.add_field(
+                name=f"**`{command_syntax}`**",
+                value=command_help,
+                inline=False,
+            )
+
+        return embed
+
+    async def send_bot_help(self, mapping: t.Dict[t.Optional[Cog], t.List[Command]]) -> None:
+        """Send general bot help."""
+        sorted_cogs = sorted(
+            mapping,
+            key=lambda cog: cog.qualified_name if cog else "ZZ"
+        )
+        cog_embeds = []
+        for cog in sorted_cogs:
+            commands = await self.filter_commands(mapping[cog])
+            if commands:
+                cog_embeds.append(await self._format_cog(cog, commands))
+
+        pages = MenuPages(
+            source=HelpPages(cog_embeds),
+            clear_reactions_after=True
+        )
+        await pages.start(self.context)
+
+    async def send_cog_help(self, cog: Cog) -> None:
+        """Send help for specific cog."""
+        embed = await self._format_cog(cog)
         await self.context.send(embed=embed)
-        # TODO: Schedule deletion
+
+    async def send_command_help(self, command: Command) -> None:
+        """Send help for specific command."""
+        embed = await self._fromat_command(command)
+        await self.context.send(embed=embed)
 
 
 class Help(Cog):

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -162,14 +162,14 @@ class HelpCommand(BaseHelpCommand):
         embed = await self._format_cog(cog)
         await self.context.send(embed=embed)
 
-    async def send_command_help(self, command: Command) -> None:
-        """Send help for specific command."""
-        embed = await self._fromat_command(command)
-        await self.context.send(embed=embed)
-
     async def send_group_help(self, group: Group) -> None:
         """Send help for specific group."""
         embed = await self._format_group(group)
+        await self.context.send(embed=embed)
+
+    async def send_command_help(self, command: Command) -> None:
+        """Send help for specific command."""
+        embed = await self._fromat_command(command)
         await self.context.send(embed=embed)
 
 

--- a/bot/core/converters.py
+++ b/bot/core/converters.py
@@ -12,6 +12,7 @@ from discord.ext.commands import (
     MemberConverter, MemberNotFound,
     UserConverter, UserNotFound
 )
+from loguru import logger
 
 
 def _obtain_user_id(argument: str) -> t.Optional[int]:
@@ -63,8 +64,7 @@ class Unicode(Converter):
                 line = line.replace("`<ESCAPE STRING>`", "'''")
                 lines[index] = line
             except SyntaxError as error:
-                print(line)
-                print(f"String deemed unsafe -> {error}")
+                logger.info(f"Unicode message conversion failed on line: {line}, string considered unsafe ({error})")
 
         return "\n".join(lines)
 

--- a/bot/utils/pages.py
+++ b/bot/utils/pages.py
@@ -1,0 +1,22 @@
+import typing as t
+
+from discord import Embed
+from discord.ext.commands import Context
+from discord.ext.menus import ListPageSource, Menu, MenuPages
+
+
+class EmbedPages(ListPageSource):
+    def __init__(self, embeds: t.List[Embed], embeds_per_page: int = 1):
+        self.embeds = embeds
+        super().__init__(embeds, per_page=embeds_per_page)
+
+    async def format_page(self, menu: Menu, embed: Embed) -> Embed:
+        """Return the stored embed for current page."""
+        return embed
+
+    async def start(self, ctx: Context, **menupages_kwargs) -> None:
+        pages = MenuPages(
+            source=self,
+            **menupages_kwargs
+        )
+        await pages.start(ctx)


### PR DESCRIPTION
## Summary
A custom help command is pretty much mandatory in any good discord bot since the default help looks very bad and doesn't support pagination. This PR aims to add this help system here.

## Details
I've decided to use [discord.py menus](https://github.com/Rapptz/discord-ext-menus) which is an experimental library for discord.py. While I'm usually not a fan of using experimental libraries, this one is quite stable and the benefits it provides outweigh the risks. Considering pagination can be easily done with a single class consisting of 2 very small functions.

## Help system
These are the specific help commands supported:

### Single command help
This is the most commonly used help, invoked by a simple `/help <command>`
Here are some example photos:
<details>

<summary>
Common command help custom embed
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96514410-e8b26600-1263-11eb-84bc-9a1af205d24a.png)

</p>
</details>

<details>

<summary>
Invoking help on command user can't access
</summary>

<p>

In this case, I've simply decided to raise `CheckFailure` which triggers the error handler, resulting in this:
![image](https://user-images.githubusercontent.com/20902250/96514520-0aabe880-1264-11eb-81b5-d432c80aae9c.png)

</p>
</details>

### Group command help
Group commands are dealt with in the same way as commands are, with an additional `Subcommands` field containing syntax for all of the group's subcommands and help for them.
<details>

<summary>
Example of group help embed
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96521651-0090e680-1272-11eb-8b9d-0eb317baff3f.png)

</p>
</details>

### Cog help embed
Cog help is similar to general help, but it doesn't hold the commands from the whole bot, but only from a single cog.
<details>

<summary>
Example of cog help embed
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96521839-75642080-1272-11eb-9e2f-504cd68b60a9.png)

</p>
</details>

### General help embed
This is the pure `/help` command without any arguments, it holds every single command available to given user.

<details>

<summary>
Example of general help embed
</summary>

<p>

![image](https://user-images.githubusercontent.com/20902250/96521984-c5db7e00-1272-11eb-87af-cc686f1977ec.png)

</p>
</details>