### PR TITLE
Fix lock feature bugs

### DIFF
--- a/bot/cogs/moderation/lock.py
+++ b/bot/cogs/moderation/lock.py
@@ -137,15 +137,18 @@ class Lock(Cog):
     def cog_unload(self) -> None:
         """Send a modlog message about the channels which were left unsilenced"""
         self.timer.abort_all()
-        for guild, channels in self.locked_channels.items():
+
+        for guild, channels in self.previous_permissions.items():
             moderator_role_id = self.roles_db.get_staff_role(guild.id)
             if moderator_role_id:
-                message = f"<@&{moderator_role_id}> "
+                message = f"⚠️ <@&{moderator_role_id}> "
             else:
-                message = ""
-            message += "This channel was left locked after lock cog unloaded"
-            for channel in channels:
+                message = "⚠️ "
+            message += "This channel was left locked after lock cog unloaded, performing automatic unlock"
+
+            for channel in channels.keys():
                 asyncio.create_task(channel.send(message))
+                asyncio.create_task(self._unlock(channel))
 
     async def cog_check(self, ctx: Context) -> bool:
         """

--- a/bot/cogs/moderation/lock.py
+++ b/bot/cogs/moderation/lock.py
@@ -144,9 +144,10 @@ class Lock(Cog):
                 message = f"⚠️ <@&{moderator_role_id}> "
             else:
                 message = "⚠️ "
-            message += "This channel was left locked after lock cog unloaded, performing automatic unlock"
+            message += "This channel was left locked after lock cog unloaded, performing automatic unlock."
 
             for channel in channels.keys():
+                logger.debug(f"Channel #{channel} ({channel.id}) was left locked after lock cog unloaded, performing automatic unlock.")
                 asyncio.create_task(channel.send(message))
                 asyncio.create_task(self._unlock(channel))
 

--- a/bot/core/timer.py
+++ b/bot/core/timer.py
@@ -125,3 +125,4 @@ class Timer:
             exception = executed_task.exception()
             if exception:
                 logger.error(f"Exception ocurred while executing {self.id}:{task_name} ({id(executed_task)})")
+                raise exception


### PR DESCRIPTION
The lock feature we were using didn't support certain edge cases such as these:
- Resetting the permission to what it was, not `/` (There might be some cases when the original permission was set to ALLOW rather than NO ACTION, in these cases, the original feature wouldn't respect this and the permission would get reset)
- Unlocking channel which was locked manually (not by previous lock command), this was allowed in the original version, while this wasn't a huge problem, it would be better to send a message informing the moderator that the channel is silenced manually and that if he wants to unsilence it, he'll have to use the channel permission system directly.
- Manually unlocking the channel while it was locked would result in a `This channel isn't silenced` message once the silence timer expired, this shouldn't be the case as it is unclear for moderators what has happende exactly, in these cases a more informative message will be sent, which looks like this: `This channel was already unsilenced manually, no action taken.`