### PR TITLE
Invite autoremove

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![mit](https://img.shields.io/badge/Licensed%20under-GPL-red.svg?style=flat-square)](./LICENSE)
 ![Python package](https://github.com/Codin-Nerds/Neutron-Bot/workflows/Python%20package/badge.svg)
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python%203.8-ffe900.svg?longCache=true&style=flat-square&colorB=00a1ff&logo=python&logoColor=88889e)](https://www.python.org/)
-[![Discord](https://img.shields.io/static/v1?label=The%20Codin'%20Nerds&logo=discord&message=%3E300%20members&color=%237289DA&logoColor=white)](https://discord.gg/Dhz9pM7)
+[![Discord](https://img.shields.io/static/v1?label=The%20Codin'%20Nerds&logo=discord&message=%3E500%20members&color=%237289DA&logoColor=white)](https://discord.gg/Dhz9pM7)
 
 ## About the bot
 

--- a/bot/cogs/automod/invites.py
+++ b/bot/cogs/automod/invites.py
@@ -1,0 +1,46 @@
+import textwrap
+
+from discord import Color, Embed, Message
+from discord.ext.commands import Cog
+from loguru import logger
+
+from bot.core.bot import Bot
+from bot.core.converters import DiscordInvite
+
+
+class InviteDetect(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @Cog.listener()
+    async def on_message(self, message: Message) -> None:
+        """
+        Check every message for valid discord invites as advertisement prevention.
+        If an invite is found, and the user doesn't have manage messages rights in
+        given channel, the message will be automatically removed.
+        """
+        valid_invite = DiscordInvite.extract_invite(message.content)
+        if not valid_invite:
+            return
+
+        if message.author.permissions_in(message.channel).manage_messages:
+            return
+
+        logger.debug(f"User {message.author.id} has posted discord invite link: {valid_invite.string}")
+
+        await message.delete()
+        embed = Embed(
+            title="Your message got zapped by our spam filter.",
+            description=textwrap.dedent(
+                """
+                We don't allow posting discord invites, it is considered advertisement
+                which we don't support, please avoid spamming them, or you will get muted.
+                """
+            ),
+            color=Color.red()
+        )
+        await message.channel.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    bot.add_cog(InviteDetect(bot))

--- a/bot/core/bot.py
+++ b/bot/core/bot.py
@@ -65,7 +65,7 @@ class Bot(Base_Bot):
     def run(self, token: t.Optional[str]) -> None:
         """Override the default `run` method and add a missing token check"""
         if not token:
-            logger.error("Missing Bot Token!")
+            logger.critical("Missing Bot Token!")
         else:
             super().run(token)
 


### PR DESCRIPTION
Posting server invites in the chat is not welcome in most servers, this cog is a handler for that, which scans every message for a discord invite, and in case it finds one, the message will get removed.

This would also block server admins from posting these, which is a problem since they might want to post these invites for collaborations and similar things. Because of this, there is a handle for users with the right to manage messages in a given channel, this prevention will be ignored and the invite link will get posted normally. 

Example embed of a removed invite:
![image](https://user-images.githubusercontent.com/20902250/107525133-d06daa80-6bb6-11eb-8c1f-2dec2a4632a2.png)
